### PR TITLE
Relax peer version of esbuild (`>=0.23`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "mobx-react-lite": "4.0.7"
   },
   "peerDependencies": {
-    "esbuild": "^0.23.0"
+    "esbuild": ">=0.23"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18"
   },
   "exports": {
     "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
A lot of other esbuild plugins are using similar constraints. The plugin API has been stable over the last releases, so I think this is fine and we could still adjust the constraint again if there should indeed be some breaking changes to the API.